### PR TITLE
upgrade airflow deps in migration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,8 @@ setup(
     install_requires=[
         "dagster>=1.0.0",
         "dagster_airflow>=0.17.5",
-        "apache-airflow==2.5.0",
+        "apache-airflow==2.5.2",
         "dagster_cloud>=1.0.0",
-        # airflow dag specific dependencies
-        "docker>=5.0.3,<6.0.0",
-        "apache-airflow-providers-docker>=3.2.0,<4",
-        "apache-airflow-providers-apache-spark>=3.0.0,<4",
-        "kubernetes>=10.0.1",
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )


### PR DESCRIPTION
Summary:
2.5.0 has a CVE, so upgrade to the recommended version.
